### PR TITLE
clarify protocol

### DIFF
--- a/docs/resumable_uploads.md
+++ b/docs/resumable_uploads.md
@@ -34,8 +34,9 @@ X-Content-Type-Options: nosniff
 
 ## Create new upload
 
-We're uploading a file named 'file_sample.xml', 1820041 bytes in size.
-Since `tusd` will store the uploaded data under a unique name it generates internally, we use the `Upload-Metadata` header to preserve any non-payload data about the upload.
+We're uploading a file named 'file_sample.xml', 1820041 bytes in size. The file size __must__ be provided, using an `Upload-Length` header.
+
+Since `tusd` will store the uploaded data under a unique name it generates internally, we use the optional `Upload-Metadata` header to preserve any non-payload data about the upload.
 Note that values in `Upload-Metadata` key-value pairs __must__ be base64 encoded.
 
 ### Request:


### PR DESCRIPTION
is this true, or can the file size be modified later on? if it is, docs should make it clear that a file can't be appended to (beyond the initially-provided value).

how about metadata, is it really optional? we should probably set in stone what can / should be provided. if we make it a two-step process, maybe some oauth needs to happen between the servers too.