### PR TITLE
Ignore get_qa_results chord results

### DIFF
--- a/reportek/core/tasks.py
+++ b/reportek/core/tasks.py
@@ -72,7 +72,7 @@ def get_qa_result(job_id):
     return qa_job.envelope_file.envelope_id, qa_job.refresh()
 
 
-@app.task(ignore_result=False)
+@app.task(ignore_result=True)
 def get_qa_results():
     """
     Scheduled task to fetch results for all QAJobs not yet completed


### PR DESCRIPTION
This prevents the accumulation of currently unused result queues from the QA results parent task/chord (noticed this on a couple of the development MQ vhosts, which have them in the hundreds).
 