### PR TITLE
Remove file in protected storage dir when deleting EnvelopeFile

### DIFF
--- a/reportek/core/models/reporting.py
+++ b/reportek/core/models/reporting.py
@@ -275,6 +275,10 @@ class EnvelopeFile(models.Model):
             debug(f'renaming: {old_path} to {new_path}')
             os.rename(old_path, new_path)
 
+    def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
+        os.remove(self.file.path)
+
     def get_file_url(self):
         return reverse('core:envelope-file', kwargs={
             'pk': self.envelope_id,


### PR DESCRIPTION
Fixes an issue with EnvelopeFile deletions, where files in protected storage directory were left on disk. This caused re-uploads to gain a random suffix, in order to maintain name uniqueness.