### PR TITLE
Pending obligations endpoint in the reporter API view

### DIFF
--- a/reportek/core/serializers.py
+++ b/reportek/core/serializers.py
@@ -163,6 +163,29 @@ class ObligationSerializer(serializers.ModelSerializer):
                   'updated_at',)
 
 
+class PendingReportingCycleSerializer(serializers.ModelSerializer):
+
+    subdivisions = ReporterSubdivisionSerializer(many=True)
+
+    class Meta:
+        model = ReportingCycle
+        fields = ('id', 'reporting_start_date', 'reporting_end_date',
+                  'is_open', 'rod_url', 'created_at', 'updated_at',
+                  'subdivisions')
+
+
+class PendingObligationSerializer(serializers.ModelSerializer):
+
+    reporting_cycles = PendingReportingCycleSerializer(many=True)
+
+    class Meta:
+        model = Obligation
+        fields = ('id', 'title', 'description', 'instrument', 'terminated',
+                  'client', 'active_since', 'active_until', 'reporting_duration',
+                  'reporting_frequency', 'rod_url', 'created_at',
+                  'updated_at', 'reporting_cycles')
+
+
 class EnvelopeFileSerializer(serializers.ModelSerializer):
     class Meta:
         model = EnvelopeFile


### PR DESCRIPTION
Note that there is another implementation of a pending obligations endpoint over in #19. This one does some things differently, most importantly of which: 
 - it does not tie the endpoint to users, for which we have a requirements collection / analysis task (#92499) that needs to progress before work starts (multiple roles per user and LDAP are two early takeouts that need attention). 
- it considers the presence of envelopes when filtering pending obligations. The ones with existing envelopes from the reporter are not counted as pending (possible finer grained filtering could be considered for partial reporting coverage over subdivisions).