### PR TITLE
Using REPORTEK_GUNICORN_PORT instead of default 80

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: tusproject/tusd:latest
     env_file:
       - ./docker/demo.env
-    entrypoint: ["/go/bin/tusd", "-dir", "/srv/tusd-data", "-hooks-http", "http://app/api/${API_VERSION}/uploads/"]
+    entrypoint: ["/go/bin/tusd", "-dir", "/srv/tusd-data", "-hooks-http", "http://app:${REPORTEK_GUNICORN_PORT}/api/${API_VERSION}/uploads/"]
     volumes:
       - tusd-uploads:/srv/tusd-data
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: tusproject/tusd:latest
     env_file:
       - ./docker/demo.env
-    entrypoint: ["/go/bin/tusd", "-dir", "/srv/tusd-data", "-hooks-http", "http://app:${REPORTEK_GUNICORN_PORT}/api/${API_VERSION}/uploads/"]
+    entrypoint: ["/go/bin/tusd", "-dir", "/srv/tusd-data", "-hooks-http", "http://app:${REPORTEK_GUNICORN_PORT:-8000}/api/${API_VERSION}/uploads/"]
     volumes:
       - tusd-uploads:/srv/tusd-data
     labels:


### PR DESCRIPTION
This allow tusd to properly use the HTTP hooks from app when containerized.