### PR TITLE
Fix error in PendingObligationMixin

### DIFF
--- a/reportek/core/api/views/mixins.py
+++ b/reportek/core/api/views/mixins.py
@@ -4,6 +4,7 @@ from django.db.models import Q, Exists, OuterRef
 from rest_framework import viewsets
 
 from ...models import (
+    Obligation,
     ReporterSubdivisionCategory,
     ReportingCycle,
     Envelope,
@@ -114,6 +115,10 @@ class PendingObligationsMixin:
                 for spec in obligation_specs
                 if spec and spec.obligation in user_obligations
             }
+            reporting_cycles = [
+                rc for rc in reporting_cycles
+                if rc.obligation_spec.obligation in user_obligations
+            ]
         else:
             obligations = {
                 spec.obligation_id: spec.obligation


### PR DESCRIPTION
This fixes an error that manifests when a Reporter has an obligation with an open ReportingCycle, but current user has no permission on the related Obligation.