### PR TITLE
Extra details on envelopes & workflows for workspace listing

### DIFF
--- a/reportek/core/serializers.py
+++ b/reportek/core/serializers.py
@@ -244,6 +244,7 @@ class NestedEnvelopeWorkflowSerializer(
     class Meta(EnvelopeWorkflowSerializer.Meta):
         fields = ('current_state', 'previous_state',
                   'available_transitions', 'upload_allowed',
+                  'updated_at',
                   )
         extra_kwargs = {
             'url': {
@@ -356,3 +357,15 @@ class WorkspaceUserSerializer(serializers.ModelSerializer):
 
 class WorkspaceEnvelopeSerializer(EnvelopeSerializer):
     files = EnvelopeFileSerializer(many=True, read_only=True)
+    obligation = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_obligation(obj):
+        return WorkspaceObligationSerializer(obj.obligation_spec.obligation).data
+
+
+class WorkspaceObligationSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Obligation
+        fields = ('id', 'title')


### PR DESCRIPTION
This adds obligation details on envelopes serialized for workspace use, and `updated_at` to the workflow serializer (to serve as an indicator of last envelope transition timestamp).
